### PR TITLE
[Feat] 현재 페이지 번호 기억하기

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,8 @@ import Navigation from '#components/Navigation';
 import Footer from '#components/Footer';
 
 export const metadata: Metadata = {
-    title: 'ForFree Blog',
-    description: '포프리 블로그입니다.',
+    title: '손동민 기술 블로그',
+    description: '손동민 기술 블로그입니다.',
 };
 
 export default function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
 }>) {
     return (
         <html>
-            <body className="min-h-screen relative bg-slate-100 border-b border-black flex flex-col">
+            <body className="min-h-screen relative bg-slate-100 flex flex-col">
                 <Navigation />
                 <div className="grow flex justify-center">
                     <div className="my-width p-4 sm:p-8 border-x border-black">

--- a/src/components/PostPagination.tsx
+++ b/src/components/PostPagination.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { MetaData } from '#utils/markdown';
 import PreviewLink from './PreviewLink';
 
@@ -9,7 +9,15 @@ type PostPaginationProps = {
 };
 
 const PostPagination = ({ metaDatas }: PostPaginationProps) => {
-    const [currentPage, setCurrentPage] = useState(0);
+    const [currentPage, setCurrentPage] = useState(
+        sessionStorage.getItem('_CURRENT_PAGE')
+            ? Number(sessionStorage.getItem('_CURRENT_PAGE'))
+            : 0,
+    );
+
+    useEffect(() => {
+        sessionStorage.setItem('_CURRENT_PAGE', String(currentPage));
+    }, [currentPage]);
 
     const handlePrev = () => {
         if (currentPage > 0) {


### PR DESCRIPTION
## 요약

- 현재 페이지 번호 기억하기

## 변경 사항

- 현재 목록 페이지 번호 기억 후, 리다이렉트 시에도 유지
- 세션 스토리지 활용

## 참고 사항

- 헤더의 홈 버튼을 누르면 초기화되는 게 어떨까?

## 이슈 번호

- close #22 
